### PR TITLE
fix: LaunchDaemon gcloud project isolation and SA key path

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -59,6 +59,24 @@ sudo vi /etc/macos-ddns6/ddns6.conf
 sudo launchctl load /Library/LaunchDaemons/com.github.macos-ddns6.plist
 ```
 
+> **LaunchDaemon 使用時の必須事項**（どちらか欠けると無言で失敗します）
+>
+> 1. **サービスアカウントキーを root が読めるパスに置く**
+>    macOS TCC により、`root` は `/Users/<user>/` 配下のファイルを読めない場合があります。
+>    キーを `/etc/macos-ddns6/` にコピーしてください：
+>    ```bash
+>    sudo cp sa-dns-updater.json /etc/macos-ddns6/sa-dns-updater.json
+>    sudo chmod 600 /etc/macos-ddns6/sa-dns-updater.json
+>    ```
+>    そして `/etc/macos-ddns6/ddns6.conf` に `GOOGLE_APPLICATION_CREDENTIALS="/etc/macos-ddns6/sa-dns-updater.json"` を設定します。
+>
+> 2. **`CLOUDSDK_CORE_PROJECT` で GCP プロジェクトを固定する**
+>    `gcloud` は呼び出しシェルでアクティブな configuration のプロジェクトを使います。デーモン環境では意図しないプロジェクトになることがあります。
+>    `install.sh --daemon` は現在のプロジェクトを自動検出して plist に注入します。正しいか確認してください：
+>    ```bash
+>    sudo cat /Library/LaunchDaemons/com.github.macos-ddns6.plist | grep -A1 CLOUDSDK_CORE_PROJECT
+>    ```
+
 ## 設定
 
 `ddns6.conf.example` を `~/.config/macos-ddns6/ddns6.conf` にコピー：

--- a/README.ja.md
+++ b/README.ja.md
@@ -106,7 +106,31 @@ gcloud iam service-accounts keys create ~/.config/gcloud/sa-dns-updater.json \
 chmod 600 ~/.config/gcloud/sa-dns-updater.json
 ```
 
-gcloud プロバイダは `GOOGLE_APPLICATION_CREDENTIALS` で指定されたキーファイルを使って `gcloud auth activate-service-account` を自動実行します。手動での activate は不要です。
+### 認証方式
+
+gcloud プロバイダは 2 つの認証方式に対応しています：
+
+**方式 A: キーファイル（デフォルト）** — `GOOGLE_APPLICATION_CREDENTIALS` を設定すると、実行のたびに `gcloud auth activate-service-account` を自動実行します。
+
+```bash
+# ddns6.conf に設定
+GOOGLE_APPLICATION_CREDENTIALS="$HOME/.config/gcloud/sa-dns-updater.json"
+```
+
+**方式 B: gcloud configuration** — サービスアカウント専用の gcloud configuration を作成します。毎回の activate が不要になり、他のプロジェクトの認証情報と分離できます。
+
+```bash
+# 専用の configuration を作成
+gcloud config configurations create example-dns
+gcloud auth activate-service-account \
+  --key-file=~/.config/gcloud/sa-dns-updater.json
+gcloud config set project YOUR_PROJECT
+
+# 環境変数で configuration を切り替え
+export CLOUDSDK_ACTIVE_CONFIG_NAME=example-dns
+```
+
+方式 B を使う場合、設定ファイルの `GOOGLE_APPLICATION_CREDENTIALS` は空またはコメントアウトしてください。gcloud configuration が認証を担います。
 
 ## 手動実行
 

--- a/README.md
+++ b/README.md
@@ -106,7 +106,31 @@ gcloud iam service-accounts keys create ~/.config/gcloud/sa-dns-updater.json \
 chmod 600 ~/.config/gcloud/sa-dns-updater.json
 ```
 
-The gcloud provider automatically runs `gcloud auth activate-service-account` using the key file specified in `GOOGLE_APPLICATION_CREDENTIALS`. No manual activation is needed.
+### Authentication Methods
+
+The gcloud provider supports two authentication methods:
+
+**Method A: Key file (default)** — Set `GOOGLE_APPLICATION_CREDENTIALS` in your config. The provider automatically runs `gcloud auth activate-service-account` on each invocation.
+
+```bash
+# In ddns6.conf
+GOOGLE_APPLICATION_CREDENTIALS="$HOME/.config/gcloud/sa-dns-updater.json"
+```
+
+**Method B: gcloud configuration** — Create a dedicated gcloud configuration with the service account pre-activated. This avoids re-activation on every run and isolates credentials from your other gcloud projects.
+
+```bash
+# Create a dedicated configuration
+gcloud config configurations create example-dns
+gcloud auth activate-service-account \
+  --key-file=~/.config/gcloud/sa-dns-updater.json
+gcloud config set project YOUR_PROJECT
+
+# Set the configuration via environment variable
+export CLOUDSDK_ACTIVE_CONFIG_NAME=example-dns
+```
+
+When using Method B, leave `GOOGLE_APPLICATION_CREDENTIALS` unset (or empty) in your config — the gcloud configuration handles authentication.
 
 ## Manual Run
 

--- a/README.md
+++ b/README.md
@@ -59,6 +59,24 @@ sudo vi /etc/macos-ddns6/ddns6.conf
 sudo launchctl load /Library/LaunchDaemons/com.github.macos-ddns6.plist
 ```
 
+> **LaunchDaemon requirements** (important — skipping either causes silent failures):
+>
+> 1. **Service account key must be in a root-readable path.**
+>    macOS TCC may block `root` from reading files under `/Users/<user>/`.
+>    Copy the key to `/etc/macos-ddns6/` instead:
+>    ```bash
+>    sudo cp sa-dns-updater.json /etc/macos-ddns6/sa-dns-updater.json
+>    sudo chmod 600 /etc/macos-ddns6/sa-dns-updater.json
+>    ```
+>    Then set `GOOGLE_APPLICATION_CREDENTIALS="/etc/macos-ddns6/sa-dns-updater.json"` in `/etc/macos-ddns6/ddns6.conf`.
+>
+> 2. **Pin the GCP project with `CLOUDSDK_CORE_PROJECT`.**
+>    `gcloud` uses whichever configuration is active in the calling shell. In a daemon context this may be the wrong project.
+>    `install.sh --daemon` auto-detects the current project and injects it into the plist. Verify it is correct:
+>    ```bash
+>    sudo cat /Library/LaunchDaemons/com.github.macos-ddns6.plist | grep -A1 CLOUDSDK_CORE_PROJECT
+>    ```
+
 ## Configuration
 
 Copy `ddns6.conf.example` to `~/.config/macos-ddns6/ddns6.conf`:

--- a/ddns6.conf.example
+++ b/ddns6.conf.example
@@ -22,8 +22,16 @@ DNS_TTL=300
 # Cloud DNS managed zone name
 DNS_ZONE="example-com"
 
-# Path to service account key JSON
+# Path to service account key JSON.
+# LaunchAgent (default): $HOME expands to the user's home directory.
+# LaunchDaemon (--daemon): the process runs as root. $HOME becomes /var/root,
+#   and macOS TCC may block root from reading files under /Users/<user>/.
+#   Copy the key to a root-accessible path instead:
+#     sudo cp sa-key.json /etc/macos-ddns6/sa-dns-updater.json
+#     sudo chmod 600 /etc/macos-ddns6/sa-dns-updater.json
 GOOGLE_APPLICATION_CREDENTIALS="$HOME/.config/gcloud/sa-dns-updater.json"
+# LaunchDaemon example:
+# GOOGLE_APPLICATION_CREDENTIALS="/etc/macos-ddns6/sa-dns-updater.json"
 
 # Path to gcloud binary (auto-detected if not set)
 # GCLOUD="/opt/homebrew/bin/gcloud"

--- a/install.sh
+++ b/install.sh
@@ -76,6 +76,8 @@ if [[ "$DAEMON_MODE" == true ]]; then
     for gcloud_bin in /opt/homebrew/bin/gcloud /usr/local/bin/gcloud; do
         if [[ -x "$gcloud_bin" ]]; then
             CLOUDSDK_PROJECT=$("$gcloud_bin" config get-value core/project 2>/dev/null || true)
+            # gcloud prints "(unset)" (not empty) when no project is configured
+            [[ "$CLOUDSDK_PROJECT" == "(unset)" ]] && CLOUDSDK_PROJECT=""
             break
         fi
     done
@@ -95,10 +97,16 @@ else
 fi
 
 # Install plist (replace placeholders)
-sed -e "s|CLOUDSDK_PYTHON_PLACEHOLDER|$CLOUDSDK_PYTHON|" \
-    -e "s|DDNS6_CONFIG_PLACEHOLDER|$CONFIG_DIR/ddns6.conf|" \
-    -e "s|CLOUDSDK_PROJECT_PLACEHOLDER|$CLOUDSDK_PROJECT|" \
-    "$PLIST_SRC" | sudo tee "$PLIST_DST" > /dev/null
+if [[ "$DAEMON_MODE" == true ]]; then
+    sed -e "s|CLOUDSDK_PYTHON_PLACEHOLDER|$CLOUDSDK_PYTHON|" \
+        -e "s|DDNS6_CONFIG_PLACEHOLDER|$CONFIG_DIR/ddns6.conf|" \
+        -e "s|CLOUDSDK_PROJECT_PLACEHOLDER|$CLOUDSDK_PROJECT|" \
+        "$PLIST_SRC" | sudo tee "$PLIST_DST" > /dev/null
+else
+    sed -e "s|CLOUDSDK_PYTHON_PLACEHOLDER|$CLOUDSDK_PYTHON|" \
+        -e "s|DDNS6_CONFIG_PLACEHOLDER|$CONFIG_DIR/ddns6.conf|" \
+        "$PLIST_SRC" | sudo tee "$PLIST_DST" > /dev/null
+fi
 
 if [[ "$DAEMON_MODE" == true ]]; then
     sudo chown root:wheel "$PLIST_DST"

--- a/install.sh
+++ b/install.sh
@@ -68,6 +68,25 @@ if [[ -z "$CLOUDSDK_PYTHON" ]]; then
 fi
 echo "    CLOUDSDK_PYTHON: $CLOUDSDK_PYTHON"
 
+# Detect GCP project for CLOUDSDK_CORE_PROJECT (daemon mode only)
+# Prevents gcloud from inheriting the wrong active configuration when multiple
+# gcloud configs exist on the system.
+CLOUDSDK_PROJECT=""
+if [[ "$DAEMON_MODE" == true ]]; then
+    for gcloud_bin in /opt/homebrew/bin/gcloud /usr/local/bin/gcloud; do
+        if [[ -x "$gcloud_bin" ]]; then
+            CLOUDSDK_PROJECT=$("$gcloud_bin" config get-value core/project 2>/dev/null || true)
+            break
+        fi
+    done
+    if [[ -n "$CLOUDSDK_PROJECT" ]]; then
+        echo "    CLOUDSDK_CORE_PROJECT: $CLOUDSDK_PROJECT (detected from active gcloud config)"
+    else
+        echo "    WARNING: Could not detect GCP project. Edit CLOUDSDK_CORE_PROJECT in $PLIST_DST"
+        CLOUDSDK_PROJECT="YOUR_GCP_PROJECT_ID"
+    fi
+fi
+
 # Unload existing service
 if [[ "$DAEMON_MODE" == true ]]; then
     sudo launchctl unload "$PLIST_DST" 2>/dev/null || true
@@ -78,6 +97,7 @@ fi
 # Install plist (replace placeholders)
 sed -e "s|CLOUDSDK_PYTHON_PLACEHOLDER|$CLOUDSDK_PYTHON|" \
     -e "s|DDNS6_CONFIG_PLACEHOLDER|$CONFIG_DIR/ddns6.conf|" \
+    -e "s|CLOUDSDK_PROJECT_PLACEHOLDER|$CLOUDSDK_PROJECT|" \
     "$PLIST_SRC" | sudo tee "$PLIST_DST" > /dev/null
 
 if [[ "$DAEMON_MODE" == true ]]; then
@@ -90,8 +110,13 @@ echo ""
 echo "==> Next steps:"
 echo "    1. Edit $CONFIG_DIR/ddns6.conf"
 if [[ "$DAEMON_MODE" == true ]]; then
-    echo "    2. sudo launchctl load $PLIST_DST"
-    echo "    3. Check /var/log/ddns6-update.log"
+    echo "    2. Place your service account key in a root-accessible path:"
+    echo "         sudo cp sa-key.json /etc/macos-ddns6/sa-dns-updater.json"
+    echo "         sudo chmod 600 /etc/macos-ddns6/sa-dns-updater.json"
+    echo "       Then update GOOGLE_APPLICATION_CREDENTIALS in $CONFIG_DIR/ddns6.conf"
+    echo "       (macOS TCC blocks root from reading files under /Users/<user>/)"
+    echo "    3. sudo launchctl load $PLIST_DST"
+    echo "    4. Check /var/log/ddns6-update.log"
 else
     echo "    2. launchctl load $PLIST_DST"
     echo "    3. Check /tmp/ddns6-update.log"

--- a/launchd/com.github.macos-ddns6.daemon.plist
+++ b/launchd/com.github.macos-ddns6.daemon.plist
@@ -18,6 +18,11 @@
         <!-- Requires Python 3.10+. Adjust path for your environment. -->
         <key>CLOUDSDK_PYTHON</key>
         <string>CLOUDSDK_PYTHON_PLACEHOLDER</string>
+        <!-- GCP project for Cloud DNS. Prevents gcloud from inheriting the wrong
+             active configuration when multiple gcloud configs exist on the system.
+             Set by install.sh; edit if the detected project is incorrect. -->
+        <key>CLOUDSDK_CORE_PROJECT</key>
+        <string>CLOUDSDK_PROJECT_PLACEHOLDER</string>
     </dict>
     <key>RunAtLoad</key>
     <true/>


### PR DESCRIPTION
## Summary

Fixes two independent failure modes in LaunchDaemon mode (`--daemon`) with the Google Cloud DNS provider, documented in #2.

- **`install.sh`**: detect the active gcloud project and inject it as `CLOUDSDK_CORE_PROJECT` into the daemon plist, preventing the wrong GCP project from being used when multiple gcloud configurations exist on the system
- **`launchd/com.github.macos-ddns6.daemon.plist`**: add `CLOUDSDK_CORE_PROJECT` key with `CLOUDSDK_PROJECT_PLACEHOLDER` (replaced by install.sh)
- **`ddns6.conf.example`**: document that `$HOME` is not the user's home in a daemon context, and that macOS TCC blocks root from reading SA keys under `/Users/<user>/`; recommend `/etc/macos-ddns6/sa-dns-updater.json`
- **`install.sh`**: print a post-install reminder to copy the SA key to a root-accessible path in daemon mode
- **README.md / README.ja.md**: add a callout block under the `--daemon` section with both requirements

## Test plan

- [ ] `./install.sh --daemon` on a system with multiple gcloud configurations: verify `CLOUDSDK_CORE_PROJECT` is injected correctly in the installed plist
- [ ] `./install.sh --daemon` on a system without `gcloud` installed: verify it falls back gracefully with a warning
- [ ] Verify the SA key path note appears in the post-install output
- [ ] `shellcheck install.sh` passes (existing SC2034 warning on LABEL is pre-existing and unrelated)

Closes #2

🤖 Generated with [Claude Code](https://claude.com/claude-code)