### PR TITLE
chore: add Dependabot version-update config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "dependencies"


### PR DESCRIPTION
## Summary

Adds `.github/dependabot.yml` to enable weekly automated version-update PRs for GitHub Actions dependencies in this repo.

This mirrors the existing, working Dependabot config used in `shigechika/jquants-mcp` and `shigechika/github-insights`.

Note: this repo has no `pyproject.toml`, so only the `github-actions` ecosystem is configured (no `pip`/`uv` entry needed).

Dependabot *security alerts* were already enabled separately via the repo settings API — this PR only adds the version-update config file.

## Test plan

- [x] Validated YAML parses (`yaml.safe_load`)
- [ ] Human review before merge