### PR TITLE
fix: correct ddns4 daemon log path in install.sh message

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -142,7 +142,7 @@ if [[ "$DAEMON_MODE" == true ]]; then
     echo "       (macOS TCC blocks root from reading files under /Users/<user>/)"
     echo "    3. sudo launchctl load $PLIST6_DST"
     echo "       sudo launchctl load $PLIST4_DST  # if using IPv4 DDNS"
-    echo "    4. Check /var/log/ddns6-update.log and /var/log/ddns4-update.log"
+    echo "    4. Check /var/log/ddns6-update.log and /tmp/ddns4-update.log"
 else
     echo "    2. launchctl load $PLIST6_DST"
     echo "       launchctl load $PLIST4_DST  # if using IPv4 DDNS"


### PR DESCRIPTION
Closes #10.

In `--daemon` mode the completion message (install.sh:145) told users to check `/var/log/ddns4-update.log`, but `launchd/com.github.macos-ddns6.ddns4.plist` hard-codes `/tmp/ddns4-update.log` for both `StandardOutPath` and `StandardErrorPath` in **both** agent and daemon modes (it's the only ddns4 plist; unlike the ddns6 daemon plist which uses `/var/log`). So in daemon mode the ddns4 log actually lands in `/tmp`, and the message was wrong.

This is the minimal fix (make the message accurate). A more consistent alternative — giving ddns4 a `/var/log` path in daemon mode to match ddns6 — would need a separate ddns4 daemon plist or a templated log path; left as a possible follow-up.